### PR TITLE
Enforce non-empty api key

### DIFF
--- a/lib/api-key.ts
+++ b/lib/api-key.ts
@@ -60,7 +60,7 @@ export class APIKey implements Token {
 	 * @example
 	 * console.log(token.isValid());
 	 */
-	public isValid = (): boolean => true;
+	public isValid = (): boolean => !!this.key;
 
 	/**
 	 * @member getAge

--- a/tests/02-api-key.spec.ts
+++ b/tests/02-api-key.spec.ts
@@ -20,8 +20,17 @@ describe('APIKey', () => {
 	});
 
 	describe('.isValid()', () => {
-		it('should always return true', () => {
+		it('should return true for non-empty values', () => {
 			expect(apiKey.isValid()).to.equal(true);
+		});
+		it('should return false for empty token', () => {
+			expect(new APIKey('').isValid()).to.equal(false);
+		});
+		it('should return false for null/undefined values', () => {
+			expect(new APIKey((null as any) as string).isValid()).to.equal(false);
+			expect(new APIKey((undefined as any) as string).isValid()).to.equal(
+				false
+			);
 		});
 	});
 


### PR DESCRIPTION
Empty string or null value are not valid keys.

Change-type: patch
Signed-off-by: Roman Mazur <roman@balena.io>